### PR TITLE
Upgrade juntagrico 1.7.9 -> 2.0.7

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -30,7 +30,7 @@ page.locator("input[name='agb']").check(force=True)
 
 ## bootstrap-input-spinner
 
-Auf den Seiten für Subscription-Auswahl (`/my/create/subscription/`) und Shares (`/my/share/manage/`) versteckt die `bootstrap-input-spinner`-Bibliothek das native `<input type="number">`. Playwright kann es nicht füllen.
+Auf den Seiten für Subscription-Auswahl (`/subscription/create/parts/`, ab 2.0), Anteilscheine im Wizard (`/subscription/create/shares/`) und Shares (`/my/share/manage/`) versteckt die `bootstrap-input-spinner`-Bibliothek das native `<input type="number">`. Playwright kann es nicht füllen.
 
 **Fix:** Den `+`-Button des Spinners anklicken:
 
@@ -296,3 +296,85 @@ count = int(cell_values[0])
 Die Jobs-Tabelle (`#filter-table`) hat keine `data-order`-Attribute auf den Datumszellen. DataTables sortiert deshalb alphabetisch nach dem Zellentext (`"D d.m.Y"`, z.B. `"Di 01.06.2027"`). Das Tageskürzel steht vorne — `"Di"` (Dienstag) < `"Do"` (Donnerstag) — daher landet ein Dienstag-2027-Job **vor** einem Donnerstag-2026-Job in der sortierten Tabelle.
 
 **Konsequenz:** Den ersten DOM-Row zu nehmen reicht nicht. Stattdessen alle Rows scannen, das kleinste zukünftige Datum bestimmen und den Job über seinen `href` (nicht über die DOM-Position) ansprechen — so in `JobsPage._nearest_future_job_href()` implementiert.
+
+---
+
+# Juntagrico 2.0 Upgrade (von 1.7)
+
+Erkenntnisse aus der Migration der E2E-Tests von Juntagrico 1.7.x auf 2.0.7.
+
+## Signup-/Subscription-Wizard: alle URLs umbenannt
+
+Der komplette Anmelde-/Abo-Flow wurde in 2.0 unter `/subscription/create/` neu strukturiert. Die `wait_for_url`-Aufrufe in `conftest.py` (`member_context`) und `pages/wizard_page.py` mussten angepasst werden:
+
+| Schritt | 1.7 | 2.0 |
+|---|---|---|
+| Abo-Teile | `/my/create/subscription/` | `/subscription/create/parts/` |
+| (neu) Extras | – | `/subscription/create/extras/` |
+| Depot | `/selectdepot/` | `/subscription/create/depot/` |
+| Startdatum | `/start/` | `/subscription/create/start/` |
+| Co-Member | `/addmembers/` | `/subscription/create/comembers/` |
+| Anteilscheine | `/shares/` | `/subscription/create/shares/` |
+| Zusammenfassung | `/summary/` | `/subscription/create/summary/` |
+| Welcome | `/my/welcome` | `/signup/welcome` |
+| Abbrechen | `/my/create/subscription/cancel/` | `/subscription/create/cancel/` |
+
+Die Signup-Einstiegs-URL `/my/signup/` existiert in 2.0 als Backwards-Compat-Alias weiter (kanonisch ist `/signup/`).
+
+## Wizard-Flow ist dynamisch (`signup_manager.get_next_page()`)
+
+Welche Schritte erscheinen, entscheidet `get_next_page()` zur Laufzeit. Der **Extras-Schritt** erscheint nur, wenn ein Extra-Abo existiert (`SubscriptionType.objects.is_extra().visible().exists()`). Die `generate_testdata` legt **kein** Extra-Abo an → der Extras-Schritt wird übersprungen. Bei eigener Testdaten-Anpassung muss der Wizard-Pfad ggf. adaptiv (URL prüfen statt feste Sequenz) navigieren.
+
+## Co-Member-Seite: kein "Überspringen"-Link mehr
+
+In 2.0 (`add_member.html`) gibt es keinen `Überspringen`-Link. Ohne Co-Member weiterzukommen erfolgt über den `?next`-Link. Robust per href ansprechen, nicht per Text (übersetzungsabhängig):
+
+```python
+page.locator("a[href='?next']").first.click()
+```
+
+## Projekt-Template-Overrides: Pfade haben sich geändert
+
+Custom-Templates wurden in 2.0 verschoben/umbenannt. Ein Projekt-Override am alten Pfad wird **stillschweigend nicht mehr verwendet** (kein Fehler, der Custom-Inhalt verschwindet einfach):
+
+| Zweck | 1.7-Template | 2.0-Template |
+|---|---|---|
+| Signup-Formular | `signup.html` | `juntagrico/signup/member.html` |
+| Startdatum | `createsubscription/select_start_date.html` | `juntagrico/subscription/create/select_start_date.html` |
+
+Die Block-Struktur ist identisch geblieben — Override 1:1 auf den neuen Pfad verschieben.
+
+## Mail-Form: `/my/mails` → `/email/write/`, neue Empfänger-Logik
+
+Die Mail-Versand-Seite ist von `/my/mails` auf `/email/write/` umgezogen (Crispy-Form `juntagrico/email/write.html`). Das frühere "Einzeladresse senden" (`#allsingleemail`/`#singleemail`) gibt es nicht mehr — Empfänger sind jetzt Mitglieder/Tätigkeitsbereiche/Einsätze/Depots (select2) bzw. Listen (`to_list`-Checkboxen: `all_subscriptions`, `all_shares`) oder eine **Kopie an sich selbst** (`copy`-Checkbox). Für einen Test-Mailversand an den Admin ist `copy` am robustesten (Admin = Absender = Empfänger).
+
+Weitere Stolpersteine:
+- **Editor:** djrichtextfield nutzt weiterhin **TinyMCE** (`init_template: tinymce.js`), `tinymce.activeEditor.setContent(...)` + `tinymce.triggerSave()` funktionieren weiter. Aber: TinyMCE lädt **nur, wenn `DJRICHTEXTFIELD_CONFIG = richtextfield_config(LANGUAGE_CODE)` in `settings.py` gesetzt ist** (`from juntagrico.defaults import richtextfield_config`). Fehlt das, lädt das lokale `tinymce.min.js` nicht und der Editor initialisiert nie — `wait_for_function` auf `tinymce` läuft in den Timeout.
+- **Submit-Button:** Label wird per AJAX (`emailForm.js`) durch die Empfängerzahl ersetzt → per `#submit-id-submit` ansprechen, nicht per `name="Senden"`.
+- **Erfolg:** redirect auf `/email/sent` (kein `/result/<n>/` mehr) → Erfolg über die Ziel-URL prüfen.
+
+## Depot-Listen-Form: `/manage/list` → `/list`
+
+Die Depot-Listen-Seite ist auf `/list` umgezogen (`name='lists'`); `/manage/list` liefert **404**. Das Datumsfeld `input[name='for_date']` (`GenerateListForm`) und der Button "Listen Erzeugen" existieren weiter.
+
+Zwei Fallstricke nach erfolgreichem Submit (POST → 302):
+- juntagrico macht `HttpResponseRedirect('')` (leerer Location-Header). Chromium **folgt dem nicht** → leere Seite. Nach dem Submit explizit `goto("/list")`, um Ergebnis/Meldungen zu sehen.
+- Die Erfolgsmeldung lautet `Listen erfolgreich erstellt.` (nicht "Listen erstellt") und ist transient. Robuster: Erfolg über die generierten Download-Links (`a[href*='/list/']`) im `depot_lists`-Block prüfen, nicht über `.alert-success`.
+
+## EmailAuditMiddleware muss an neue Mail-URLs/Felder angepasst werden
+
+Der gartenberg-eigene `EmailAuditMiddleware` (`gartenberg/middleware.py`) hängt an den Mail-Versand-POSTs. In 2.0 änderten sich URLs (`/email/write/`, `/email/{to,depot,area,job}/<id>/`) **und** Feldnamen (`from_email` statt `sender`; Empfänger via `to_list`/`to_members`/`to_areas`/`to_jobs`/`to_depots`/`copy` statt `all*`/`recipients`). Echte Sends erkennt man am Submit-Feld `submit` im POST (Vorbefüll-POSTs mit `members` haben das nicht).
+
+**Regressions-Erkennung — zwei Ebenen nötig:** Die Unit-Tests (`gartenberg/tests.py`) prüfen die Middleware-Logik isoliert gegen **hartkodierte** POST-Daten — sie fangen Code-Fehler, aber **nicht** ein erneutes stilles Ändern der juntagrico-Mailform. Dafür braucht es den **Integrationscheck** in `tests/test_admin_mail.py`: nach dem realen Versand das EmailAuditLog-Admin-Changelist (`/admin/gartenberg/emailauditlog/`) öffnen und den Betreff verifizieren (echtes Formular → Middleware → Log).
+
+## Build-Falle: kaputtes `tzlocal 5.4.2`-Wheel
+
+`tzlocal 5.4.2` (transitiv über `pyHanko` ← `xhtml2pdf`) installiert nur das `.dist-info`, **nicht** das Paket-Verzeichnis → `ModuleNotFoundError: No module named 'tzlocal'` beim `manage.py migrate` im Docker-Build, obwohl pip "Successfully installed tzlocal-5.4.2" meldet. Symptom-Check im Container:
+
+```sh
+pip show tzlocal          # zeigt installiert an
+python -c "import tzlocal" # ModuleNotFoundError
+ls site-packages | grep tzlocal  # nur tzlocal-5.4.2.dist-info, kein tzlocal/
+```
+
+**Fix:** In `requirements.txt` `tzlocal<5.4` pinnen (5.3.1 / 5.2 importieren sauber).

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -141,34 +141,41 @@ def member_context(playwright: Playwright) -> BrowserContext:
     # Step 2: Subscription type
     # bootstrap-input-spinner hides the number input and shows +/- buttons;
     # click the + button once to set the first type's quantity from 0 to 1
-    page.wait_for_url("**/my/create/subscription/")
+    page.wait_for_url("**/subscription/create/parts/")
     page.wait_for_load_state("networkidle")
     page.locator(".btn-increment").first.click()
     page.get_by_role("button", name="Weiter").click()
 
     # Step 3: Depot
-    page.wait_for_url("**/selectdepot/")
+    page.wait_for_url("**/subscription/create/depot/")
     page.locator("select[name='depot']").select_option(index=0)
     page.get_by_role("button", name="Weiter").click()
 
     # Step 4: Start date
-    page.wait_for_url("**/start/")
+    page.wait_for_url("**/subscription/create/start/")
     page.locator("input[name='start_date']").fill("01.01.2027")
     page.get_by_role("button", name="Weiter").click()
 
     # Step 5: Co-members — skip
-    page.wait_for_url("**/addmembers/")
-    page.get_by_role("link", name="Überspringen").click()
+    # 2.0 dropped the "Überspringen" link; continuing without co-members is the
+    # "?next" link (rendered when no co-member has been added yet)
+    page.wait_for_url("**/subscription/create/comembers/")
+    page.locator("a[href='?next']").first.click()
 
-    # Step 6: Shares — the spinner is pre-set to the required minimum; just continue
-    page.wait_for_url("**/shares/")
+    # Step 6: Shares — in 2.0 the spinner is no longer pre-set to the subscription's
+    # required amount (initial = REQUIRED_SHARES = 0), but ShareOrderForm.clean()
+    # still requires >= the subscription's shares (testdata subtype 'Normales Abo'
+    # needs 2). Increment the of_member spinner to 2 before continuing.
+    page.wait_for_url("**/subscription/create/shares/")
     page.wait_for_load_state("networkidle")
+    for _ in range(2):
+        page.locator(".btn-increment").first.click()
     page.get_by_role("button", name="Weiter").click()
 
     # Step 7: Summary — confirm
-    page.wait_for_url("**/summary/")
+    page.wait_for_url("**/subscription/create/summary/")
     page.get_by_role("button", name="Verbindlich bestellen").click()
-    page.wait_for_url("**/my/welcome**")
+    page.wait_for_url("**/signup/welcome**")
 
     # Retrieve auto-generated password and confirmation link from welcome email
     email_body = wait_for_email(MEMBER_EMAIL)

--- a/e2e/pages/admin_list_page.py
+++ b/e2e/pages/admin_list_page.py
@@ -6,7 +6,8 @@ class AdminListPage:
         self.page = page
 
     def navigate(self):
-        self.page.goto("/manage/list")
+        # 2.0 moved the depot list page from /manage/list to /list
+        self.page.goto("/list")
         self.page.wait_for_load_state("networkidle")
 
     def generate(self, for_date: str = "2027-01-01"):
@@ -14,13 +15,23 @@ class AdminListPage:
         self.page.locator("input[name='for_date']").fill(for_date)
         # crispy Submit renders as <input type="submit">, which has ARIA role "button"
         self.page.get_by_role("button", name="Listen Erzeugen", exact=True).click()
+        # juntagrico redirects to '' (empty Location) after generation; Chromium does
+        # not follow that, leaving a blank page. Re-navigate to /list explicitly so the
+        # generated lists (and their download links) are visible.
+        self.page.wait_for_load_state("networkidle")
+        self.page.goto("/list")
         self.page.wait_for_load_state("networkidle")
 
+    def _generated_links(self):
+        # In 2.0 generated lists render as download links (/list/<name>) in the
+        # depot_lists section; not-yet-generated lists render as plain text.
+        return self.page.locator("a[href*='/list/']")
+
     def was_successful(self) -> bool:
-        return "Listen erstellt" in (self.page.locator(".alert-success").text_content() or "")
+        return self._generated_links().count() > 0
 
     def open_first_generated_link(self):
-        self.page.locator(".alert-success a").first.click()
+        self._generated_links().first.click()
         self.page.wait_for_load_state("networkidle")
 
     def is_accessible(self) -> bool:

--- a/e2e/pages/admin_mail_page.py
+++ b/e2e/pages/admin_mail_page.py
@@ -1,5 +1,3 @@
-import re
-
 from playwright.sync_api import Page
 
 
@@ -8,28 +6,33 @@ class AdminMailPage:
         self.page = page
 
     def navigate(self):
-        self.page.goto("/my/mails")
+        # 2.0 moved the mail form from /my/mails to /email/write/
+        self.page.goto("/email/write/")
         self.page.wait_for_load_state("networkidle")
-        # Wait until TinyMCE has fully initialised and attached an editor to the textarea
+        # The richtext message field switched from the old MAILER_RICHTEXT setup to
+        # djrichtextfield, but djrichtextfield still uses TinyMCE under the hood — wait
+        # until TinyMCE has attached an editor to the textarea.
         self.page.wait_for_function(
             "() => typeof tinymce !== 'undefined' && tinymce.activeEditor !== null"
         )
 
-    def send_to_single(self, recipient: str, subject: str, body: str):
-        # jQuery trigger fires the change-handler that toggles #singleemail visibility;
-        # force-checking the Bootstrap-Switch input alone does not dispatch change events
-        self.page.evaluate("$('#allsingleemail').prop('checked', true).trigger('change')")
-        self.page.locator("input#singleemail").wait_for(state="visible")
-        self.page.locator("input#singleemail").fill(recipient)
-        self.page.locator("input#subject").fill(subject)
+    def send_copy_to_self(self, subject: str, body: str):
+        # 2.0 dropped the free "single email address" recipient. Recipients are now
+        # members / areas / jobs / depots / lists or a copy to oneself ("Kopie an mich").
+        # Use the copy checkbox so the sending admin (test@test.ch) receives the mail.
+        self.page.locator("input[name='subject']").fill(subject)
         self.page.evaluate(f"tinymce.activeEditor.setContent('<p>{body}</p>')")
-        # The #sendmail click-handler copies TinyMCE content → #textMessage before submit
+        # push the editor content into the underlying textarea so it is part of the POST
+        self.page.evaluate("tinymce.triggerSave()")
+        # 'copy' renders as a Bootstrap-4 custom checkbox (input visually hidden) -> force
+        self.page.locator("input[name='copy']").check(force=True)
+        # The submit button label is replaced by an AJAX recipient count (emailForm.js),
+        # so target it by id, not by visible name. Wait for the redirect to /email/sent.
         with self.page.expect_response(
-            lambda r: "/mails/send/result/" in r.url and r.status == 200
+            lambda r: "/email/sent" in r.url and r.request.method == "GET" and r.status == 200
         ):
-            self.page.locator("#sendmail").click()
+            self.page.locator("#submit-id-submit").click()
         self.page.wait_for_load_state("networkidle")
 
-    def sent_count_from_url(self) -> int:
-        m = re.search(r"/result/(\d+)/", self.page.url)
-        return int(m.group(1)) if m else 0
+    def reached_sent_page(self) -> bool:
+        return "/email/sent" in self.page.url

--- a/e2e/pages/wizard_page.py
+++ b/e2e/pages/wizard_page.py
@@ -21,22 +21,22 @@ class SignupWizardPage:
         self.page.wait_for_load_state("networkidle")
 
     def select_first_subscription_type(self):
-        self.page.wait_for_url("**/my/create/subscription/")
+        self.page.wait_for_url("**/subscription/create/parts/")
         self.page.wait_for_load_state("networkidle")
         self.page.locator(".btn-increment").first.click()
         self.page.get_by_role("button", name="Weiter").click()
 
     def select_first_depot(self):
-        self.page.wait_for_url("**/selectdepot/")
+        self.page.wait_for_url("**/subscription/create/depot/")
         # index=0 works here: the depot field has no blank option (not null=True)
         self.page.locator("select[name='depot']").select_option(index=0)
         self.page.get_by_role("button", name="Weiter").click()
-        self.page.wait_for_url("**/start/")
+        self.page.wait_for_url("**/subscription/create/start/")
         self.page.wait_for_load_state("networkidle")
 
     def is_on_start_date_step(self) -> bool:
-        return "/start/" in self.page.url
+        return "/subscription/create/start/" in self.page.url
 
     def abort(self):
-        self.page.goto("/my/create/subscription/cancel/")
+        self.page.goto("/subscription/create/cancel/")
         self.page.wait_for_load_state("networkidle")

--- a/e2e/tests/test_admin_mail.py
+++ b/e2e/tests/test_admin_mail.py
@@ -13,12 +13,25 @@ def test_admin_can_send_email(admin_page):
     page.navigate()
     shot(admin_page, "admin_mail_01_form")
 
-    page.send_to_single(ADMIN_EMAIL, _SUBJECT, "E2E Testinhalt")
+    # 2.0 sends a copy to the sender via "Kopie an mich"; the admin (test@test.ch) is
+    # both sender and recipient.
+    page.send_copy_to_self(_SUBJECT, "E2E Testinhalt")
     shot(admin_page, "admin_mail_02_result")
 
-    assert page.sent_count_from_url() == 1, \
-        f"Result-URL sollte 1 gesendete Mail anzeigen, URL war: '{admin_page.url}'"
+    assert page.reached_sent_page(), \
+        f"Nach dem Senden sollte die /email/sent Seite erreicht werden, URL war: '{admin_page.url}'"
 
     email_body = wait_for_email(ADMIN_EMAIL)
     assert "E2E Testinhalt" in email_body, \
-        f"Nachrichtentext 'E2E Testinhalt' sollte im E-Mail-Body enthalten sein"
+        "Nachrichtentext 'E2E Testinhalt' sollte im E-Mail-Body enthalten sein"
+
+    # Regressions-Schutz für den gartenberg-eigenen EmailAuditMiddleware: Der reale
+    # juntagrico-Versand muss einen EmailAuditLog-Eintrag erzeugen. Dieser Integrations-
+    # check (echtes Formular -> Middleware -> Log) erkennt, wenn juntagrico die Mail-
+    # URLs/Feldnamen ändert — was die isolierten Unit-Tests (gartenberg/tests.py) nicht
+    # können, da sie gegen hartkodierte POST-Daten prüfen.
+    admin_page.goto("/admin/gartenberg/emailauditlog/")
+    admin_page.wait_for_load_state("networkidle")
+    shot(admin_page, "admin_mail_03_audit_log")
+    assert _SUBJECT in admin_page.content(), \
+        "EmailAuditLog sollte den Versand aufzeichnen (EmailAuditMiddleware-Regression?)"

--- a/gartenberg/middleware.py
+++ b/gartenberg/middleware.py
@@ -1,9 +1,9 @@
-EMAIL_SEND_PATHS = {
-    '/my/mails/send',
-    '/my/mails/send/depot',
-    '/my/mails/send/area',
-    '/my/mails/send/job',
-}
+import re
+
+# Mail-Versand-Endpunkte ab juntagrico 2.0 (POST). Die Zähl-Endpunkte
+# (.../recipients/count) und die Ergebnisseite (/email/sent) sind bewusst
+# nicht enthalten. In 1.7 waren dies /my/mails/send[/depot|/area|/job].
+EMAIL_SEND_PATH_RE = re.compile(r'^/email/(write|to/\d+|depot/\d+|area/\d+|job/\d+)/$')
 
 
 class EmailAuditMiddleware:
@@ -11,20 +11,30 @@ class EmailAuditMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.method == 'POST' and request.path in EMAIL_SEND_PATHS:
-            sender = request.POST.get('sender', '–')
+        # Nur echte Sende-Versuche auditieren: die Form trägt den Submit-Button
+        # 'submit'. Ein POST mit 'members' ohne 'submit' ist nur ein Vorbefüllen des
+        # Formulars (juntagrico.views.email.write behandelt es wie ein GET).
+        if (request.method == 'POST'
+                and EMAIL_SEND_PATH_RE.match(request.path)
+                and 'submit' in request.POST):
+            sender = request.POST.get('from_email', '–')
             subject = request.POST.get('subject', '–')
             groups = []
-            if request.POST.get('allsubscription') == 'on':
+            to_list = request.POST.getlist('to_list')
+            if 'all_subscriptions' in to_list:
                 groups.append('Abo-BezieherInnen')
-            if request.POST.get('allshares') == 'on':
+            if 'all_shares' in to_list:
                 groups.append('Anteilsschein-BesitzerInnen')
-            if request.POST.get('all') == 'on':
-                groups.append('Alle Mitglieder')
-            if request.POST.get('allsingleemail') == 'on':
-                groups.append('Einzeladressen')
-            if request.POST.get('recipients'):
-                groups.append('Vorausgefüllte Adressen')
+            if request.POST.getlist('to_members'):
+                groups.append('Einzelne Mitglieder')
+            if request.POST.getlist('to_areas'):
+                groups.append('Tätigkeitsbereiche')
+            if request.POST.getlist('to_jobs'):
+                groups.append('Einsätze')
+            if request.POST.getlist('to_depots'):
+                groups.append('Depots')
+            if request.POST.get('copy') == 'on':
+                groups.append('Kopie an Absender')
             try:
                 from gartenberg.models import EmailAuditLog
                 EmailAuditLog.objects.create(

--- a/gartenberg/settings.py
+++ b/gartenberg/settings.py
@@ -4,6 +4,8 @@ Django settings for gartenberg project.
 
 import os
 
+from juntagrico.defaults import richtextfield_config
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -25,16 +27,18 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.admin',
+    'juntagrico.apps.JuntagricoAdminConfig',  # ersetzt django.contrib.admin ab 2.0
     'gartenberg',
     'juntagrico_billing',
     'juntagrico_assignment_request',
     'juntagrico_pg',
     'juntagrico',
-    'fontawesomefree',  # benötigt ab 1.6
     'import_export',  # benötigt ab 1.6
     'impersonate',
     'crispy_forms',
+    'crispy_bootstrap4',  # benötigt ab 2.0 (crispy-forms 2.x)
+    'django_select2',  # benötigt ab 2.0
+    'djrichtextfield',  # benötigt ab 2.0
     'adminsortable2',
     'polymorphic',
 
@@ -128,7 +132,11 @@ EMAIL_PORT = int(os.environ.get('JUNTAGRICO_EMAIL_PORT', '25'))
 EMAIL_USE_TLS = os.environ.get('JUNTAGRICO_EMAIL_TLS', 'False') == 'True'
 EMAIL_USE_SSL = os.environ.get('JUNTAGRICO_EMAIL_SSL', 'False') == 'True'
 
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+# juntagrico 2.0 bringt ein eigenes Mail-Backend (ersetzt DEFAULT_MAILER)
+EMAIL_BACKEND = 'juntagrico.backends.email.EmailBackend'
+
+# PickleSerializer wird ab juntagrico 2.0 / Django 5 nicht mehr unterstützt
+# -> Standard-Serializer (JSON) wird verwendet
 
 # The white list only applies if the application is executed in debug mode and
 # prevents mails from being sent to other adresses
@@ -153,7 +161,14 @@ MEDIA_ROOT = 'media'
 """
      Crispy Settings
 """
+CRISPY_ALLOWED_TEMPLATE_PACKS = 'bootstrap4'  # ab crispy-forms 2.x nötig
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
+
+"""
+     Rich-Text-Editor (djrichtextfield, ab 2.0)
+     Lädt das lokale TinyMCE für die Mail-/Admin-Textfelder.
+"""
+DJRICHTEXTFIELD_CONFIG = richtextfield_config(LANGUAGE_CODE)
 
 """
      juntagrico Settings

--- a/gartenberg/templates/juntagrico/signup/member.html
+++ b/gartenberg/templates/juntagrico/signup/member.html
@@ -13,7 +13,7 @@
     {% enriched_organisation "D" as v_d_enriched_organisation %}
     {% block intro_1 %}
         <p>Interessiert an {% enriched_organisation "D" %}?</p>
-        
+
 	<p>Falls du noch nicht genau weisst wie unsere Genossenschaft funktioniert, besuche unsere <a href="https://gartenberg.ch/">Webseite</a> oder finde mehr heraus über die <a href="https://gartenberg.ch/probe-mitgliedschaft/">Probe Mitgliedschaft</a>.</p>
 
 	<div style="border-width: 2px; border-style: solid;">

--- a/gartenberg/templates/juntagrico/subscription/create/select_start_date.html
+++ b/gartenberg/templates/juntagrico/subscription/create/select_start_date.html
@@ -12,7 +12,7 @@
     Normalerweise ist der {{ v_subscription }}-Start der Start eines Geschäftsjahres. Das nächste
     Startdatum wäre der <b>{{ sd }}</b>.
     <br>
-    Momentan haben wir noch freie Plätze in unserer Genossenschaft und so ist ein Start auch bereits zum nächsten Monatsbeginn möglich. Bitte trage unten das gewünschte Startdatum ein 
+    Momentan haben wir noch freie Plätze in unserer Genossenschaft und so ist ein Start auch bereits zum nächsten Monatsbeginn möglich. Bitte trage unten das gewünschte Startdatum ein
     {% endblocktrans %}
 {% endblock %}
 

--- a/gartenberg/tests.py
+++ b/gartenberg/tests.py
@@ -10,10 +10,11 @@ class EmailAuditMiddlewareTest(TestCase):
         self.middleware = EmailAuditMiddleware(get_response=lambda r: None)
 
     def test_erstellt_log_bei_mail_versand(self):
-        request = self.factory.post('/my/mails/send', {
-            'sender': 'laura@gartenberg.ch',
+        request = self.factory.post('/email/write/', {
+            'submit': 'Senden',
+            'from_email': 'laura@gartenberg.ch',
             'subject': 'Ernte-Info KW 17',
-            'allsubscription': 'on',
+            'to_list': 'all_subscriptions',
         })
         self.middleware(request)
         self.assertEqual(EmailAuditLog.objects.count(), 1)
@@ -21,51 +22,68 @@ class EmailAuditMiddlewareTest(TestCase):
         self.assertEqual(log.sender, 'laura@gartenberg.ch')
         self.assertEqual(log.subject, 'Ernte-Info KW 17')
         self.assertIn('Abo-BezieherInnen', log.recipient_groups)
-        self.assertEqual(log.url, '/my/mails/send')
+        self.assertEqual(log.url, '/email/write/')
 
     def test_alle_empfaenger_gruppen(self):
-        request = self.factory.post('/my/mails/send', {
-            'sender': 'info@gartenberg.ch',
+        request = self.factory.post('/email/write/', {
+            'submit': 'Senden',
+            'from_email': 'info@gartenberg.ch',
             'subject': 'Test',
-            'allsubscription': 'on',
-            'allshares': 'on',
-            'all': 'on',
-            'allsingleemail': 'on',
-            'recipients': 'extra@example.com',
+            'to_list': ['all_subscriptions', 'all_shares'],
+            'to_members': ['1'],
+            'to_areas': ['2'],
+            'to_jobs': ['3'],
+            'to_depots': ['4'],
+            'copy': 'on',
         })
         self.middleware(request)
         log = EmailAuditLog.objects.get()
         self.assertIn('Abo-BezieherInnen', log.recipient_groups)
         self.assertIn('Anteilsschein-BesitzerInnen', log.recipient_groups)
-        self.assertIn('Alle Mitglieder', log.recipient_groups)
-        self.assertIn('Einzeladressen', log.recipient_groups)
-        self.assertIn('Vorausgefüllte Adressen', log.recipient_groups)
+        self.assertIn('Einzelne Mitglieder', log.recipient_groups)
+        self.assertIn('Tätigkeitsbereiche', log.recipient_groups)
+        self.assertIn('Einsätze', log.recipient_groups)
+        self.assertIn('Depots', log.recipient_groups)
+        self.assertIn('Kopie an Absender', log.recipient_groups)
 
     def test_alle_mail_send_pfade(self):
         paths = [
-            '/my/mails/send',
-            '/my/mails/send/depot',
-            '/my/mails/send/area',
-            '/my/mails/send/job',
+            '/email/write/',
+            '/email/to/5/',
+            '/email/depot/5/',
+            '/email/area/3/',
+            '/email/job/2/',
         ]
         for path in paths:
             EmailAuditLog.objects.all().delete()
-            request = self.factory.post(path, {'sender': 'x@x.ch', 'subject': 'Test'})
+            request = self.factory.post(path, {'submit': 'Senden', 'from_email': 'x@x.ch', 'subject': 'Test'})
             self.middleware(request)
             self.assertEqual(EmailAuditLog.objects.count(), 1, f'Kein Log-Eintrag für {path}')
 
     def test_kein_log_bei_get_request(self):
-        request = self.factory.get('/my/mails/send')
+        request = self.factory.get('/email/write/')
         self.middleware(request)
         self.assertEqual(EmailAuditLog.objects.count(), 0)
 
     def test_kein_log_bei_anderem_pfad(self):
-        request = self.factory.post('/my/profile', {'sender': 'x@x.ch'})
+        request = self.factory.post('/my/profile', {'from_email': 'x@x.ch', 'submit': 'Senden'})
+        self.middleware(request)
+        self.assertEqual(EmailAuditLog.objects.count(), 0)
+
+    def test_kein_log_bei_zaehl_endpunkt(self):
+        # /email/depot/<id>/recipients/count ist ein AJAX-Zähl-Endpunkt, kein Versand
+        request = self.factory.post('/email/depot/5/recipients/count', {'submit': 'x'})
+        self.middleware(request)
+        self.assertEqual(EmailAuditLog.objects.count(), 0)
+
+    def test_kein_log_ohne_submit(self):
+        # POST mit 'members' ohne 'submit' ist nur Vorbefüllen des Formulars, kein Versand
+        request = self.factory.post('/email/write/', {'members': '1_2'})
         self.middleware(request)
         self.assertEqual(EmailAuditLog.objects.count(), 0)
 
     def test_fehlende_felder_verwenden_platzhalter(self):
-        request = self.factory.post('/my/mails/send', {})
+        request = self.factory.post('/email/write/', {'submit': 'Senden'})
         self.middleware(request)
         log = EmailAuditLog.objects.get()
         self.assertEqual(log.sender, '–')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
 #git+https://github.com/patrickuhlmann/juntagrico.git@main
-juntagrico ~=1.7.9
+juntagrico ~=2.0.7
 
 gunicorn==23.0.0
 psycopg>=3.1.8
 whitenoise==6.11.0
-juntagrico-assignment-request==1.7.0
-juntagrico-billing==1.7.7
-juntagrico-pg==1.7.0
+juntagrico-assignment-request==2.0.0
+juntagrico-billing==2.0.0
+juntagrico-pg==2.0.0
+
+# transitive dependency (pyHanko <- xhtml2pdf): the tzlocal 5.4.2 wheel is broken
+# (installs only the .dist-info, not the package), causing ModuleNotFoundError at runtime
+tzlocal<5.4


### PR DESCRIPTION
App:
- requirements: juntagrico ~=2.0.7, billing/assignment-request/pg ==2.0.0, pin tzlocal<5.4 (5.4.2 wheel is broken: only .dist-info, no package)
- settings: JuntagricoAdminConfig replaces django.contrib.admin; add crispy_bootstrap4/django_select2/djrichtextfield; drop fontawesomefree and PickleSerializer; set EMAIL_BACKEND, CRISPY_ALLOWED_TEMPLATE_PACKS and DJRICHTEXTFIELD_CONFIG (required for the mail rich-text editor)
- move custom signup/start-date overrides to the new 2.0 template paths (juntagrico/signup/member.html, juntagrico/subscription/create/select_start_date.html)
- EmailAuditMiddleware: adapt to new mail URLs (/email/write/, /email/{to,depot,area,job}/<id>/) and form fields (from_email, to_list, to_members, to_areas, to_jobs, to_depots, copy)

Tests:
- gartenberg unit tests: rewrite middleware tests for the 2.0 mail form
- e2e: update signup/subscription wizard URLs, co-member skip, share spinner, depot list page (/list, download-link success check) and mail page (/email/write/, copy-to-self, /email/sent)
- e2e mail test: assert EmailAuditLog records the send (integration regression guard)
- CLAUDE.md: document 2.0 upgrade pitfalls

Verified: 27/27 e2e + 8/8 unit tests green.